### PR TITLE
CSV Encodings and Special cases for Rady/Tricity

### DIFF
--- a/src/chargemaster_parsers/parsers/lluh.py
+++ b/src/chargemaster_parsers/parsers/lluh.py
@@ -27,7 +27,9 @@ class LLUHChargeMasterParser(ChargeMasterParser):
 
         for artifact in artifacts:
             location = self.URL_TO_INSTITUTION[artifact]
-            reader = csv.reader(io.TextIOWrapper(artifacts[artifact], encoding='cp1252', newline=''))
+            reader = csv.reader(
+                io.TextIOWrapper(artifacts[artifact], encoding="cp1252", newline="")
+            )
             headers = None
             for row in reader:
                 if headers is None:

--- a/src/chargemaster_parsers/parsers/lluh.py
+++ b/src/chargemaster_parsers/parsers/lluh.py
@@ -27,7 +27,7 @@ class LLUHChargeMasterParser(ChargeMasterParser):
 
         for artifact in artifacts:
             location = self.URL_TO_INSTITUTION[artifact]
-            reader = csv.reader(io.TextIOWrapper(artifacts[artifact]))
+            reader = csv.reader(io.TextIOWrapper(artifacts[artifact], encoding='cp1252', newline=''))
             headers = None
             for row in reader:
                 if headers is None:

--- a/src/chargemaster_parsers/parsers/rady.py
+++ b/src/chargemaster_parsers/parsers/rady.py
@@ -36,7 +36,14 @@ class RadyChargeMasterParser(ChargeMasterParser):
                 if itemcode_index is not None:
                     procedure_identifier = row[itemcode_index].value
 
-                description = row[description_index].value[4:].strip()  # Remove "RCH "
+                description = row[description_index].value
+                cpt_code = None
+                match = re.match(r"^\s*(\(.+?\))?\s*RCH\s*(.+?)$", description)
+                if match:
+                    cpt_code = match.groups()[0]
+                    description = match.groups()[1]
+                    if cpt_code:
+                        cpt_code = cpt_code[1:-1]
 
                 try:
                     price = row[price_index].value
@@ -47,6 +54,7 @@ class RadyChargeMasterParser(ChargeMasterParser):
                         procedure_identifier=procedure_identifier,
                         procedure_description=description,
                         gross_charge=price,
+                        cpt_code=cpt_code,
                     )
                 except ValueError as ex:
                     pass

--- a/src/chargemaster_parsers/parsers/tricity.py
+++ b/src/chargemaster_parsers/parsers/tricity.py
@@ -22,7 +22,11 @@ class TriCityChargeMasterParser(ChargeMasterParser):
             "Max ($)",
         )
 
-        reader = csv.reader(io.TextIOWrapper(artifacts[self.ARTIFACT_URL], encoding='cp1252', newline=''))
+        reader = csv.reader(
+            io.TextIOWrapper(
+                artifacts[self.ARTIFACT_URL], encoding="cp1252", newline=""
+            )
+        )
         headers = None
         for row in reader:
             if headers is None:
@@ -82,11 +86,19 @@ class TriCityChargeMasterParser(ChargeMasterParser):
                 code = row_dict_values["Code"]
                 procedure_identifier = code_type + "_" + code
 
+                if procedure_description:
+                    match = re.match(rf'^\s*({code})?[^a-zA-Z0-9()]*(.+?)\s*$', procedure_description)
+                    procedure_description = match.groups()[1]
+
                 if code_type == "DRG":
                     ms_drg_code = str(int(code)).rjust(3, "0")
                 elif code_type == "CDM":
-                    if re.match(r"[0-9]{4}[0-9A-Za-z]$", code):
+                    if re.match(r"^[0-9]{4}[0-9A-Za-z]$", code):
                         cpt_code = code
+                    elif "|" in code:
+                        # These are likely two HCPCs combined with | but rare
+                        extra_data["Code Type"] = code_type
+                        extra_data["Code"] = code
                     else:
                         hcpcs_code = code
                 elif code_type in ("ICD10", "ICD9", "Softcoded", "Pharmacy"):

--- a/src/chargemaster_parsers/parsers/tricity.py
+++ b/src/chargemaster_parsers/parsers/tricity.py
@@ -22,7 +22,7 @@ class TriCityChargeMasterParser(ChargeMasterParser):
             "Max ($)",
         )
 
-        reader = csv.reader(io.TextIOWrapper(artifacts[self.ARTIFACT_URL]))
+        reader = csv.reader(io.TextIOWrapper(artifacts[self.ARTIFACT_URL], encoding='cp1252', newline=''))
         headers = None
         for row in reader:
             if headers is None:

--- a/src/chargemaster_parsers/parsers/tricity.py
+++ b/src/chargemaster_parsers/parsers/tricity.py
@@ -87,7 +87,9 @@ class TriCityChargeMasterParser(ChargeMasterParser):
                 procedure_identifier = code_type + "_" + code
 
                 if procedure_description:
-                    match = re.match(rf'^\s*({code})?[^a-zA-Z0-9()]*(.+?)\s*$', procedure_description)
+                    match = re.match(
+                        rf"^\s*({code})?[^a-zA-Z0-9()]*(.+?)\s*$", procedure_description
+                    )
                     procedure_description = match.groups()[1]
 
                 if code_type == "DRG":

--- a/tests/test_rady.py
+++ b/tests/test_rady.py
@@ -93,7 +93,11 @@ def test_cpt(parser):
     ws.cell(row=1, column=2, value="Item Description")
     ws.cell(row=1, column=3, value="Load Price")
     ws.cell(row=2, column=1, value="00829502")
-    ws.cell(row=2, column=2, value="(99202) RCH EXPANDED PROBLEM FOCUSED,STRAIGHTFORWARD-20MIN")
+    ws.cell(
+        row=2,
+        column=2,
+        value="(99202) RCH EXPANDED PROBLEM FOCUSED,STRAIGHTFORWARD-20MIN",
+    )
     ws.cell(row=2, column=3, value=300.00)
 
     expected_result = [

--- a/tests/test_rady.py
+++ b/tests/test_rady.py
@@ -86,6 +86,36 @@ def test_simple_row_v2(parser):
     assert sorted(expected_result) == sorted(actual_result)
 
 
+def test_cpt(parser):
+    wb = Workbook()
+    ws = wb.active
+    ws.cell(row=1, column=1, value="Itemcode")
+    ws.cell(row=1, column=2, value="Item Description")
+    ws.cell(row=1, column=3, value="Load Price")
+    ws.cell(row=2, column=1, value="00829502")
+    ws.cell(row=2, column=2, value="(99202) RCH EXPANDED PROBLEM FOCUSED,STRAIGHTFORWARD-20MIN")
+    ws.cell(row=2, column=3, value=300.00)
+
+    expected_result = [
+        ChargeMasterEntry(
+            procedure_identifier="00829502",
+            procedure_description="EXPANDED PROBLEM FOCUSED,STRAIGHTFORWARD-20MIN",
+            cpt_code="99202",
+            gross_charge=300.0,
+        ),
+    ]
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        filename = os.path.join(tmp_dir, "rady.xlsx")
+        wb.save(filename)
+        actual_result = list(
+            parser.parse_artifacts(
+                {RadyChargeMasterParser.ARTIFACT_URL: open(filename, "rb")}
+            )
+        )
+    assert sorted(expected_result) == sorted(actual_result)
+
+
 def test_institution_name(parser):
     assert RadyChargeMasterParser.institution_name == "Rady"
     assert parser.institution_name == "Rady"

--- a/tests/test_tricity.py
+++ b/tests/test_tricity.py
@@ -327,7 +327,7 @@ def test_cpt_ip(parser):
             max_reimbursement=214.2,
             min_reimbursement=168.3,
             payer="Multiplan Commercial",
-            procedure_description="51701 INSERTION STRAIGHT CATHETERTECH FEE",
+            procedure_description="INSERTION STRAIGHT CATHETERTECH FEE",
             procedure_identifier="CDM_51701",
             in_patient=True,
             nubc_revenue_code="450",
@@ -339,7 +339,7 @@ def test_cpt_ip(parser):
             max_reimbursement=214.2,
             min_reimbursement=168.3,
             payer="Sharp Health Plan (HMO,PPO,Covered California)",
-            procedure_description="51701 INSERTION STRAIGHT CATHETERTECH FEE",
+            procedure_description="INSERTION STRAIGHT CATHETERTECH FEE",
             procedure_identifier="CDM_51701",
             in_patient=True,
             nubc_revenue_code="450",
@@ -348,7 +348,7 @@ def test_cpt_ip(parser):
             cpt_code="51701",
             gross_charge=183.6,
             payer="Cash",
-            procedure_description="51701 INSERTION STRAIGHT CATHETERTECH FEE",
+            procedure_description="INSERTION STRAIGHT CATHETERTECH FEE",
             procedure_identifier="CDM_51701",
             in_patient=True,
             nubc_revenue_code="450",
@@ -380,7 +380,7 @@ def test_cpt_op(parser):
             max_reimbursement=214.2,
             min_reimbursement=168.3,
             payer="Multiplan Commercial",
-            procedure_description="51701 INSERTION STRAIGHT CATHETERTECH FEE",
+            procedure_description="INSERTION STRAIGHT CATHETERTECH FEE",
             procedure_identifier="CDM_51701",
             in_patient=False,
             nubc_revenue_code="450",
@@ -392,7 +392,7 @@ def test_cpt_op(parser):
             max_reimbursement=214.2,
             min_reimbursement=168.3,
             payer="Sharp Health Plan (HMO,PPO,Covered California)",
-            procedure_description="51701 INSERTION STRAIGHT CATHETERTECH FEE",
+            procedure_description="INSERTION STRAIGHT CATHETERTECH FEE",
             procedure_identifier="CDM_51701",
             in_patient=False,
             nubc_revenue_code="450",
@@ -401,10 +401,116 @@ def test_cpt_op(parser):
             cpt_code="51701",
             gross_charge=183.6,
             payer="Cash",
-            procedure_description="51701 INSERTION STRAIGHT CATHETERTECH FEE",
+            procedure_description="INSERTION STRAIGHT CATHETERTECH FEE",
             procedure_identifier="CDM_51701",
             in_patient=False,
             nubc_revenue_code="450",
+        ),
+    ]
+
+    assert sorted(expected_result) == sorted(actual_result)
+
+
+def test_leading_bad_characters(parser):
+    test_case = 'CDM,96360,"96360 - HYDRATION, FIRST HOUR",IP,260,$315.00 ,$189.00 , NA , NA , NA  , NA , NA , NA , NA , NA , NA , NA , NA , NA , NA  ,$220.50 , NA , NA  ,$173.25 , NA , NA , NA , NA  , NA , NA  , NA  , NA  , NA  , NA  , NA  , NA  , NA  , NA ,$173.25 ,$220.50 '
+
+    test_case = HEADER + "\n" + test_case
+    actual_result = list(
+        parser.parse_artifacts(
+            {
+                TriCityChargeMasterParser.ARTIFACT_URL: io.BytesIO(
+                    test_case.encode("utf-8")
+                )
+            }
+        )
+    )
+
+    expected_result = [
+        ChargeMasterEntry(
+            cpt_code="96360",
+            expected_reimbursement=220.5,
+            gross_charge=315.0,
+            in_patient=True,
+            max_reimbursement=220.5,
+            min_reimbursement=173.25,
+            nubc_revenue_code="260",
+            payer="Multiplan Commercial",
+            procedure_description="HYDRATION, FIRST HOUR",
+            procedure_identifier="CDM_96360",
+        ),
+        ChargeMasterEntry(
+            cpt_code="96360",
+            expected_reimbursement=173.25,
+            gross_charge=315.0,
+            in_patient=True,
+            max_reimbursement=220.5,
+            min_reimbursement=173.25,
+            nubc_revenue_code="260",
+            payer="Sharp Health Plan (HMO,PPO,Covered California)",
+            procedure_description="HYDRATION, FIRST HOUR",
+            procedure_identifier="CDM_96360",
+        ),
+        ChargeMasterEntry(
+            cpt_code="96360",
+            gross_charge=189.0,
+            in_patient=True,
+            nubc_revenue_code="260",
+            payer="Cash",
+            procedure_description="HYDRATION, FIRST HOUR",
+            procedure_identifier="CDM_96360",
+        ),
+    ]
+
+    assert sorted(expected_result) == sorted(actual_result)
+
+
+def test_pipe(parser):
+    test_case = 'CDM,1-86671|2-86671,"SACCHAROMYCES CEREVISIAE IGG, IGA ARUP",IP,302,$56.40 ,$33.84 , NA , NA , NA  , NA , NA , NA , NA , NA , NA , NA , NA , NA , NA  ,$39.48 , NA , NA  ,$31.02 , NA , NA , NA , NA  , NA , NA  , NA  , NA  , NA  , NA  , NA  , NA  , NA  , NA ,$31.02 ,$39.48 '
+
+    test_case = HEADER + "\n" + test_case
+    actual_result = list(
+        parser.parse_artifacts(
+            {
+                TriCityChargeMasterParser.ARTIFACT_URL: io.BytesIO(
+                    test_case.encode("utf-8")
+                )
+            }
+        )
+    )
+
+    expected_result = [
+        ChargeMasterEntry(
+            expected_reimbursement=39.48,
+            extra_data={"Code Type": "CDM", "Code": "1-86671|2-86671"},
+            gross_charge=56.4,
+            in_patient=True,
+            max_reimbursement=39.48,
+            min_reimbursement=31.02,
+            nubc_revenue_code="302",
+            payer="Multiplan Commercial",
+            procedure_description="SACCHAROMYCES CEREVISIAE IGG, IGA ARUP",
+            procedure_identifier="CDM_1-86671|2-86671",
+        ),
+        ChargeMasterEntry(
+            expected_reimbursement=31.02,
+            extra_data={"Code Type": "CDM", "Code": "1-86671|2-86671"},
+            gross_charge=56.4,
+            in_patient=True,
+            max_reimbursement=39.48,
+            min_reimbursement=31.02,
+            nubc_revenue_code="302",
+            payer="Sharp Health Plan (HMO,PPO,Covered California)",
+            procedure_description="SACCHAROMYCES CEREVISIAE IGG, IGA ARUP",
+            procedure_identifier="CDM_1-86671|2-86671",
+        ),
+        ChargeMasterEntry(
+            extra_data={"Code Type": "CDM", "Code": "1-86671|2-86671"},
+            gross_charge=33.84,
+            in_patient=True,
+            nubc_revenue_code="302",
+            payer="Cash",
+            procedure_description="SACCHAROMYCES CEREVISIAE IGG, IGA ARUP",
+            procedure_identifier="CDM_1-86671|2-86671",
         ),
     ]
 


### PR DESCRIPTION
Windows defaults to cp1252 but most Linux doesn't. A few of the new CSV's aren't UTF-8 so they needed to be explicitly specified. Also handle some cases for Tricity and RDH where the code is embedded in the description.